### PR TITLE
allow more versions of pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='block-io',
       packages=['block_io'],
       install_requires=[
           'requests>=2.20.0',
-          'pycryptodome==3.6.6',
+          'pycryptodome>=3.6.6',
           'ecdsa==0.13',
           'six>=1.8.0',
           'base58>=1.0.0'


### PR DESCRIPTION
This dependency was arbitrarily freezed but later versions are working properly (tested with 3.7.3)